### PR TITLE
OneHotEncoder now uses MetricRegistry. 

### DIFF
--- a/src/skprometheus/metrics.py
+++ b/src/skprometheus/metrics.py
@@ -3,10 +3,11 @@ from skprometheus.prom_client_utils import add_labels
 
 
 class _MetricRegistry:
-    """Object for initiation and upkeep of metrics. Necessary for avoiding assignment and label conflicts."""
+    """Object for initiation and upkeep of metrics. Necessary to avoid assignment and labeling conflicts."""
     def __init__(self):
         self.labels = set()
         self.metrics_initialized = False
+        self.categorical_metrics_initialized = False
         self.current_labels = {}
         self.DEFAULT_LATENCY_BUCKETS = (0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25,
                                         0.5, 0.75, 1., 2.5, 5., 7.5, 10., float('inf'))
@@ -45,6 +46,16 @@ class _MetricRegistry:
             labelnames=tuple(self.labels)
         )
 
+    def _init_categorical_metrics(self):
+        if self.categorical_metrics_initialized:
+            return
+        self.categorical_metrics_initialized = True
+        self._model_categorical = Counter(
+            "model_categorical",
+            "Counts category occurrence for each categorical feature.",
+            labelnames=tuple(self.labels) + ("feature", "category")
+        )
+
     def label(self, **labels):
         self.current_labels = labels
         return self
@@ -71,6 +82,11 @@ class _MetricRegistry:
     def model_exception(self):
         self._init_metrics()
         return add_labels(self._model_exception, self.current_labels)
+
+    def model_categorical(self, **labels):
+        self._init_categorical_metrics()
+        labels = dict(labels, **self.current_labels)
+        return add_labels(self._model_categorical, labels)
 
 
 MetricRegistry = _MetricRegistry()

--- a/src/skprometheus/preprocessing.py
+++ b/src/skprometheus/preprocessing.py
@@ -1,20 +1,12 @@
 from sklearn import preprocessing
-from prometheus_client import Counter
 from sklearn.utils.validation import _get_feature_names
+from skprometheus.metrics import MetricRegistry
 
 
 class OneHotEncoder(preprocessing.OneHotEncoder):
     """
     OneHotEncoder that adds metrics to the prometheus metric registry.
     """
-    def __init__(self, *args, prom_labels=None, **kwargs):
-        self.prom_labels = prom_labels or {}
-        self.model_categorical = Counter(
-            "model_categorical",
-            "Counts category occurrence for each categorical feature.",
-            labelnames=tuple(self.prom_labels.keys()) + ("feature", "category")
-        )
-        super().__init__(*args, **kwargs)
 
     def transform(self, X):
         """
@@ -34,6 +26,6 @@ class OneHotEncoder(preprocessing.OneHotEncoder):
             for category in row:
                 if not category:
                     category = "missing"
-                self.model_categorical.labels(feature=str(features[idx]), category=str(category)).inc()
+                MetricRegistry.model_categorical(feature=str(features[idx]), category=str(category)).inc()
 
         return transformed_X

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,3 +18,6 @@ def unregister_collectors():
     MetricRegistry.metrics_initialized = False
     MetricRegistry.current_labels = {}
     MetricRegistry.labels = set()
+
+    # Reset categorical
+    MetricRegistry.categorical_metrics_initialized = False

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -47,3 +47,14 @@ def test_pipeline_exceptions():
                 continue
 
         assert REGISTRY.get_sample_value('model_exception_total', {'Test': 'exceptions'}) == 4
+
+
+def test_pipeline_count():
+    pipeline = Pipeline([
+        ('clf', FixedLatencyClassifier(0.095))
+    ])
+    pipeline.predict(np.ones((15, 3)))
+    pipeline.predict(np.ones((22, 3)))
+
+    assert 'model_predict' in [m.name for m in REGISTRY.collect()]
+    assert REGISTRY.get_sample_value('model_predict_total') == 37

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -14,9 +14,9 @@ def test_OneHotEncoder():
         [6, 7, 8, 9]
     ])
 
-    assert 'model_categorical' in [m.name for m in REGISTRY.collect()]
     one_hot.fit(X)
     one_hot.transform(X)
+    assert 'model_categorical' in [m.name for m in REGISTRY.collect()]
 
     assert REGISTRY.get_sample_value('model_categorical_total', {'feature': '2', 'category': '4'}) == 2
     assert REGISTRY.get_sample_value('model_categorical_total', {'feature': '3', 'category': '9'}) == 1


### PR DESCRIPTION
Changes: 

- OneHotencoder now uses metricRegistry
- Test added for Pipeline predict counter
- Categorical metrics (for One-hot) are initialised separately from the other metrics in _init_categorical_metrics method. This is to avoid creating metrics that are not used. --> Is this a good way to do this?


 